### PR TITLE
fix(admin): 回填发布者主题色并修复配置页输入框溢出

### DIFF
--- a/src/main/resources/admin/assets/admin.css
+++ b/src/main/resources/admin/assets/admin.css
@@ -2036,6 +2036,19 @@
     .config-field-control textarea {
       min-height: 120px;
     }
+    @container (max-width: 620px) {
+      .config-field-main,
+      .config-toggle-field .config-field-main {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 10px;
+      }
+      .config-field-control {
+        width: 100%;
+      }
+      .config-switch-control {
+        justify-content: flex-start;
+      }
+    }
     .config-toggle-field .config-field-main {
       grid-template-columns: minmax(220px, 1fr) auto;
     }
@@ -5426,6 +5439,7 @@
     }
     .config-tab-stage {
       min-width: 0;
+      container-type: inline-size;
       display: grid;
       gap: 14px;
     }

--- a/src/main/resources/admin/assets/admin.css
+++ b/src/main/resources/admin/assets/admin.css
@@ -2036,6 +2036,9 @@
     .config-field-control textarea {
       min-height: 120px;
     }
+    .config-toggle-field .config-field-main {
+      grid-template-columns: minmax(220px, 1fr) auto;
+    }
     @container (max-width: 620px) {
       .config-field-main,
       .config-toggle-field .config-field-main {
@@ -2048,9 +2051,6 @@
       .config-switch-control {
         justify-content: flex-start;
       }
-    }
-    .config-toggle-field .config-field-main {
-      grid-template-columns: minmax(220px, 1fr) auto;
     }
     .config-switch-control {
       position: relative;

--- a/src/main/resources/admin/pages/entities.js
+++ b/src/main/resources/admin/pages/entities.js
@@ -1088,16 +1088,19 @@ function collectCreateSubscriberTargets(targetController) {
 async function openEditPublisher(id) {
   if (!state.cache.publishers) state.cache.publishers = await api("/publishers");
   const item = state.cache.publishers.find(row => Number(row.id) === Number(id));
+  const initialThemeColors = Array.isArray(item.drawTheme?.backgroundColors)
+    ? item.drawTheme.backgroundColors.filter(Boolean).join(";")
+    : "";
   openModal("编辑发布者", `
     <div class="form-grid">
       <div class="field"><label>状态</label><select id="entityState">${entityStateOptions(item.state)}</select></div>
       <div class="field full"><label>头图</label><input id="entityHeader" value="${attr(item.bannerUri || "")}"></div>
-      <div class="field full"><label>主题色</label><div class="command-permission-toolbar"><input id="entityThemeColors" placeholder="#FE65A6;#BFFAFF"><button type="button" class="secondary" id="entityClearThemeButton"${item.drawTheme ? "" : " disabled"}>清除主题色</button></div><span class="inline-note">多个颜色用英文分号分隔；留空表示不修改。</span></div>
+      <div class="field full"><label>主题色</label><div class="command-permission-toolbar"><input id="entityThemeColors" value="${attr(initialThemeColors)}" placeholder="#FE65A6;#BFFAFF"><button type="button" class="secondary" id="entityClearThemeButton"${item.drawTheme ? "" : " disabled"}>清除主题色</button></div><span class="inline-note">多个颜色用英文分号分隔；留空表示不修改。</span></div>
     </div>
   `, async () => {
     const body = { headerUri: $("entityHeader").value, state: $("entityState").value };
     const themeColors = $("entityThemeColors").value.trim();
-    if (themeColors) body.themeColors = themeColors;
+    if (themeColors && themeColors !== initialThemeColors) body.themeColors = themeColors;
     await api(`/publishers/${id}`, { method: "PATCH", body: JSON.stringify(body) });
     closeModal();
     invalidate("publishers", "subscriptions", "dashboard");

--- a/src/test/kotlin/top/colter/dynamic/admin/AdminServerTest.kt
+++ b/src/test/kotlin/top/colter/dynamic/admin/AdminServerTest.kt
@@ -1907,11 +1907,16 @@ class AdminServerTest {
         )
         val listed = service.publishers().single()
 
-        assertNotNull(themed.drawTheme)
+        val storedTheme = assertNotNull(PublisherDrawThemeRepository.findByPublisherId(publisher.id))
+        val themedTheme = assertNotNull(themed.drawTheme)
         val listedTheme = assertNotNull(listed.drawTheme)
         assertEquals(
+            storedTheme.palette.backgroundColors,
+            themedTheme.backgroundColors,
+        )
+        assertEquals(
+            storedTheme.palette.backgroundColors,
             listedTheme.backgroundColors,
-            PublisherDrawThemeRepository.findByPublisherId(publisher.id)!!.palette.backgroundColors,
         )
 
         val cleared = service.updatePublisher(


### PR DESCRIPTION
编辑发布者时，主题色输入框会显示已保存的主题背景色。
仅改状态或头图时，不再重复提交主题色，避免无意重算主题。
配置页面右侧可用宽度不足时，字段说明和输入框自动改为上下排列，输入框不再越出卡片。
增强后端测试，确保更新接口和发布者列表都会返回数据库中已保存的主题色。