### PR TITLE
Retry transient image download failures

### DIFF
--- a/src/main/kotlin/top/colter/dynamic/draw/image/DynamicImageLoader.kt
+++ b/src/main/kotlin/top/colter/dynamic/draw/image/DynamicImageLoader.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -131,7 +132,14 @@ public class HttpImageDownloader(
     private val client: HttpClient = HttpClient.newBuilder()
         .followRedirects(HttpClient.Redirect.NORMAL)
         .build(),
+    private val maxHttpAttempts: Int = DEFAULT_HTTP_ATTEMPTS,
+    private val retryBaseDelayMillis: Long = DEFAULT_HTTP_RETRY_BASE_DELAY_MILLIS,
 ) : ImageDownloader {
+    init {
+        require(maxHttpAttempts >= 1) { "HTTP 下载尝试次数至少为 1" }
+        require(retryBaseDelayMillis >= 0) { "HTTP 下载重试间隔不能为负数" }
+    }
+
     override suspend fun download(uri: String, timeoutMs: Long, maxBytes: Long): ByteArray {
         val parsed = runCatching { URI(uri) }.getOrNull()
         return try {
@@ -155,21 +163,44 @@ public class HttpImageDownloader(
     }
 
     private suspend fun downloadHttp(uri: String, timeoutMs: Long, maxBytes: Long): ByteArray {
+        var lastFailure: ImageDownloadException? = null
+        repeat(maxHttpAttempts) { attempt ->
+            try {
+                return downloadHttpOnce(uri, timeoutMs, maxBytes)
+            } catch (e: ImageDownloadException) {
+                if (!e.isTransientHttpFailure() || attempt == maxHttpAttempts - 1) throw e
+                lastFailure = e
+                delay(retryBaseDelayMillis * (attempt + 1L))
+            }
+        }
+        throw checkNotNull(lastFailure)
+    }
+
+    private suspend fun downloadHttpOnce(uri: String, timeoutMs: Long, maxBytes: Long): ByteArray {
         val request = HttpRequest.newBuilder(URI(uri))
             .timeout(Duration.ofMillis(timeoutMs))
             .GET()
             .build()
-        val response = client
-            .sendAsync(request, HttpResponse.BodyHandlers.ofInputStream())
-            .awaitHttp(uri)
-        if (response.statusCode() !in 200..299) {
-            response.body().close()
-            throw ImageDownloadException("HTTP ${response.statusCode()}")
+        try {
+            val response = client
+                .sendAsync(request, HttpResponse.BodyHandlers.ofInputStream())
+                .awaitHttp(uri)
+            if (response.statusCode() !in 200..299) {
+                response.body().close()
+                throw ImageDownloadException("HTTP ${response.statusCode()}")
+            }
+            response.headers().firstValueAsLong("Content-Length")
+                .takeIf { it.isPresent && it.asLong > maxBytes }
+                ?.let {
+                    response.body().close()
+                    throw ImageDownloadException("图片超过大小限制：size=${it.asLong}，maxBytes=$maxBytes")
+                }
+            return response.body().use { input -> readBytesLimited(input, maxBytes) }
+        } catch (e: ImageDownloadException) {
+            throw e
+        } catch (e: IOException) {
+            throw ImageDownloadException(e.message ?: "请求失败：$uri", e)
         }
-        response.headers().firstValueAsLong("Content-Length")
-            .takeIf { it.isPresent && it.asLong > maxBytes }
-            ?.let { throw ImageDownloadException("图片超过大小限制：size=${it.asLong}，maxBytes=$maxBytes") }
-        return response.body().use { input -> readBytesLimited(input, maxBytes) }
     }
 
     private fun readFileLimited(path: Path, maxBytes: Long): ByteArray {
@@ -205,6 +236,10 @@ public class HttpImageDownloader(
     }
 }
 
+private fun ImageDownloadException.isTransientHttpFailure(): Boolean {
+    return generateSequence(cause) { it.cause }.any { it is IOException }
+}
+
 private suspend fun <T> CompletableFuture<T>.awaitHttp(uri: String): T {
     return try {
         await()
@@ -233,3 +268,6 @@ private fun secondsToMillis(seconds: Double, minimumMillis: Long): Long {
     if (seconds <= 0.0 && minimumMillis <= 0) return 0
     return (seconds * 1_000.0).roundToLong().coerceAtLeast(minimumMillis)
 }
+
+private const val DEFAULT_HTTP_ATTEMPTS: Int = 3
+private const val DEFAULT_HTTP_RETRY_BASE_DELAY_MILLIS: Long = 200

--- a/src/test/kotlin/top/colter/dynamic/listener/CachedDynamicImageLoaderTest.kt
+++ b/src/test/kotlin/top/colter/dynamic/listener/CachedDynamicImageLoaderTest.kt
@@ -1,14 +1,17 @@
 ﻿package top.colter.dynamic.listener
 
+import com.sun.net.httpserver.HttpServer
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
+import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicInteger
 import javax.imageio.ImageIO
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.exists
 import kotlin.io.path.writeBytes
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -114,6 +117,74 @@ class CachedDynamicImageLoaderTest {
         assertEquals(bytes.size, loaded.size)
     }
 
+    @Test
+    fun httpDownloaderShouldRetryWhenResponseBodyIsTruncated(): Unit = runBlocking {
+        val attempts = AtomicInteger()
+        val expected = pngBytes(Color.ORANGE)
+        val server = truncatedResponseServer(expected, attempts, failuresBeforeSuccess = 1)
+
+        try {
+            val loaded = HttpImageDownloader(
+                maxHttpAttempts = 3,
+                retryBaseDelayMillis = 1,
+            ).download(server.url(), timeoutMs = 1_000, maxBytes = 1024)
+
+            assertContentEquals(expected, loaded)
+            assertEquals(2, attempts.get())
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun httpDownloaderShouldStopAfterConfiguredAttemptsForTruncatedResponses(): Unit = runBlocking {
+        val attempts = AtomicInteger()
+        val expected = pngBytes(Color.PINK)
+        val server = truncatedResponseServer(expected, attempts, failuresBeforeSuccess = Int.MAX_VALUE)
+
+        try {
+            try {
+                HttpImageDownloader(
+                    maxHttpAttempts = 3,
+                    retryBaseDelayMillis = 1,
+                ).download(server.url(), timeoutMs = 1_000, maxBytes = 1024)
+                fail("truncated responses should fail after the configured attempts")
+            } catch (_: ImageDownloadException) {
+            }
+            assertEquals(3, attempts.get())
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun httpDownloaderShouldNotRetryPermanentHttpErrors(): Unit = runBlocking {
+        val attempts = AtomicInteger()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/missing.png") { exchange ->
+                exchange.use {
+                    attempts.incrementAndGet()
+                    exchange.sendResponseHeaders(404, -1)
+                }
+            }
+            start()
+        }
+
+        try {
+            try {
+                HttpImageDownloader(
+                    maxHttpAttempts = 3,
+                    retryBaseDelayMillis = 1,
+                ).download("http://127.0.0.1:${server.address.port}/missing.png", timeoutMs = 1_000, maxBytes = 1024)
+                fail("permanent HTTP errors should fail immediately")
+            } catch (_: ImageDownloadException) {
+            }
+            assertEquals(1, attempts.get())
+        } finally {
+            server.stop(0)
+        }
+    }
+
     private fun loader(
         sourceRoot: String,
         maxConcurrentDownloads: Int = 8,
@@ -157,4 +228,24 @@ class CachedDynamicImageLoaderTest {
             output.toByteArray()
         }
     }
+
+    private fun truncatedResponseServer(
+        bytes: ByteArray,
+        attempts: AtomicInteger,
+        failuresBeforeSuccess: Int,
+    ): HttpServer {
+        return HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/image.png") { exchange ->
+                exchange.use {
+                    val attempt = attempts.incrementAndGet()
+                    val truncated = attempt <= failuresBeforeSuccess
+                    exchange.sendResponseHeaders(200, bytes.size.toLong() + if (truncated) 10 else 0)
+                    exchange.responseBody.write(bytes)
+                }
+            }
+            start()
+        }
+    }
+
+    private fun HttpServer.url(): String = "http://127.0.0.1:${address.port}/image.png"
 }


### PR DESCRIPTION
## What changed

- Retry transient HTTP image download failures up to three total attempts.
- Use short incremental delays (200 ms, then 400 ms) between retries.
- Keep permanent failures such as HTTP status errors, invalid paths, and image size violations fail-fast.
- Preserve the existing placeholder fallback after retries are exhausted.
- Add regression coverage for truncated response recovery, retry exhaustion, and non-retryable HTTP errors.

## Why

The image downloader previously made a single attempt. If the server sent valid response headers but the connection stalled or closed while the response body was being read, Java raised an `IOException` such as `EOF reached while reading`. That exception was immediately converted into a placeholder image, causing occasional missing Bilibili covers during transient network degradation.

## Impact

Short-lived EOF, timeout, and connection interruptions can now recover without replacing the requested image with a placeholder. Permanent errors still fail immediately, so retries do not add delay to invalid requests.

## Validation

- `gradlew test --tests top.colter.dynamic.listener.CachedDynamicImageLoaderTest` — passed.
- `gradlew fatJar` — passed; produced `dynamic-bot-0.0.8-all.jar`.
- Full test suite: 482/483 passed. The remaining pre-existing `DrawConfigTest` failure is a Windows `AccessDeniedException` while overwriting a loaded temporary font file and reproduces independently of this change.
